### PR TITLE
Supress error when the server return 200 and intentionally return no content

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,16 @@ module.exports = function(grunt) {
         return next();
     };
 
+    //to test put
+    var putMiddleware = function(req, res, next) {
+        if (req.method === 'PUT') {
+            return res.end(JSON.stringify({
+                body : req.body
+            }));
+        }
+        return next();
+    };
+
     //load npm tasks
     require('load-grunt-tasks')(grunt);
 
@@ -84,7 +94,7 @@ module.exports = function(grunt) {
                     port: 9901,
                     base: '.',
                     middleware: function(connect, options, middlewares) {
-                        return [connect.bodyParser(), postMiddleware, jsonpMiddleware, timeMiddleware].concat(middlewares);
+                        return [connect.bodyParser(), postMiddleware, putMiddleware, jsonpMiddleware, timeMiddleware].concat(middlewares);
                     },
                 }
             },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,14 @@ module.exports = function(grunt) {
         return next();
     };
 
+    //to test if no content 200 response doesn't trigger error
+    var nocontentMiddleware = function(req, res, next) {
+        if (req.method === 'POST') {
+            return res.end();
+        }
+        return next();
+    };
+
     //load npm tasks
     require('load-grunt-tasks')(grunt);
 
@@ -94,7 +102,7 @@ module.exports = function(grunt) {
                     port: 9901,
                     base: '.',
                     middleware: function(connect, options, middlewares) {
-                        return [connect.bodyParser(), postMiddleware, putMiddleware, jsonpMiddleware, timeMiddleware].concat(middlewares);
+                        return [connect.bodyParser(), postMiddleware, nocontentMiddleware, putMiddleware, jsonpMiddleware, timeMiddleware].concat(middlewares);
                     },
                 }
             },

--- a/src/aja.js
+++ b/src/aja.js
@@ -170,7 +170,7 @@
              */
             method : function(method){
                return _chain.call(this, 'method', method, validators.method, function(value){
-                    if(value.toLowerCase() === 'post'){
+                    if(value.toLowerCase() !== 'get'){
                         this.header('Content-Type', 'application/x-www-form-urlencoded;charset=utf-8');
                     }
                     return value;

--- a/src/aja.js
+++ b/src/aja.js
@@ -400,7 +400,9 @@
 
                ajaGo._xhr.call(this, url, function processRes(res){
                     try {
-                        res = JSON.parse(res);
+                        if(res){
+                            res = JSON.parse(res);
+                        }
                     } catch(e){
                         self.trigger('error', e);
                         return null;

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -80,6 +80,22 @@ describe('aja()', function(){
             .go();
     });
 
+    it('should not trigger error on JSON access when 200 returned and intentionally returned no content', function(done){
+        aja()
+        .url('/nocontent')
+        .method('post')
+        .type('json')
+        .data({ kill: 'bill'})
+        .on('success', function(data){
+            expect(data).not.to.be.ok();
+            done();
+        })
+        .on('error', function() {
+            expect.fail('Should NOT trigger error when 200 returned even no content returned.');
+        })
+        .go();
+    });
+
     it('should put urlencoded data', function(done){
         aja()
             .url('/put')

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -80,6 +80,20 @@ describe('aja()', function(){
             .go();
     });
 
+    it('should put urlencoded data', function(done){
+        aja()
+            .url('/put')
+            .method('put')
+            .data({ kill: 'him'})
+            .on('success', function(data){
+                expect(data).to.be.an('object');
+                expect(data.body).to.be.an('object');
+                expect(data.body).to.contain.keys(['kill']);
+                done();
+            })
+            .go();
+    });
+
     it('should load the json sample and trigger a 200', function(done){
         aja()
             .url('/test/samples/data.json')


### PR DESCRIPTION
On JSON access, if the server returns 200 and intentionally return no content, error is triggered.
`JSON.parse(res)` tries to parse response content, but it is actually null (i.e. not JSON) and throws error.