### PR TITLE
.timeout() feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,24 @@ aja.js  [![Build Status](https://travis-ci.org/krampstudio/aja.js.png)](https://
 
 [![Npm Downloads](https://nodei.co/npm/aja.png?downloads=true&stars=true)](https://nodei.co/npm/aja.png?downloads=true&stars=true)
 
+### Difference with the original/krampstudio's aja.js: timeout!
+There's a new function called `timeout`. Guess what its job is going to be? :)
 
+```javascript
+  aja()
+    .timeout(2500)
+    .url('/api/data.json')
+    .on('success', function(data){
+      //data is a JavaScript object
+    })
+    .on('timeout', function(err){
+      // This will be executed if the server will take more than 2.5s to respond.
+      // In this case, the XHR call will be ended thru XHR's `.abort()` function.
+      console.log(err.type); // outputs the string 'timeout'
+      console.log(err.expiredAfter); // outputs '2500' (eg: the timeout value in ms)
+    }
+    .go();
+```
 
 ## Basic Sample
 
@@ -34,9 +51,13 @@ More options using the fluent api, terrific REST client.
   aja()
     .method('GET')
     .url('/api/customer')
+    .timeout(2500)
     .data({firstname: 'John Romuald'})
     .on('200', function(response){
         //well done
+    })
+    .on('timeout', functon(){
+        // uh oh... Request ended. Do something fancy here, don't let your user wait forever!
     })
     .go();
 

--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
-    "chai": "^1.9.1",
-    "istanbul": "^0.3.2",
-    "mocha": "^2.0.1",
-    "load-grunt-tasks": "^0.4.0",
-    "grunt-contrib-connect": "^0.8.0",
-    "grunt-contrib-uglify": "^0.6.0",
+    "chai": "^3.0.0",
+    "istanbul": "^0.3.17",
+    "mocha": "^2.2.5",
+    "load-grunt-tasks": "^3.2.0",
+    "grunt-contrib-connect": "^0.10.1",
+    "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-istanbul": "^0.3.0",
-    "grunt-mocha-phantom-istanbul": "^0.1.1",
-    "grunt-jsdoc" : "^0.6.0"
+    "grunt-istanbul": "^0.6.1",
+    "grunt-mocha-phantom-istanbul": "^0.2.1",
+    "grunt-jsdoc": "^0.6.7"
   },
   "keywords" : [
     "ajax",

--- a/src/aja.js
+++ b/src/aja.js
@@ -160,6 +160,19 @@
             },
 
             /**
+             * Sets a timeout (expressed in ms) after which it will halt the request and the 'timeout' event will be fired.
+             *
+             * @example aja().timeout(1000); // Terminate the request and fire the 'timeout' event after 1s
+             *
+             * @throws TypeError
+             * @param {Number} [ms] - timeout in ms to set. It has to be an integer > 0.
+             * @returns {Aja|String} chains or get the params
+             */
+            timeout : function(ms){
+                return _chain.call(this, 'timeout', ms, validators.positiveInteger);
+            },
+
+            /**
              * HTTP method getter/setter.
              *
              * @example aja().method('post');
@@ -438,6 +451,8 @@
                 var body        = data.body;
                 var headers     = data.headers || {};
                 var contentType = this.header('Content-Type');
+                var timeout     = data.timeout;
+                var timeoutId;
                 var isUrlEncoded;
                 var openParams;
 
@@ -509,6 +524,18 @@
                 request.onerror = function onRequestError (err){
                     self.trigger('error', err, arguments);
                 };
+
+                //sets the timeout
+                if (timeout) {
+                    timeoutId = setTimeout(function() {
+                        request.abort();
+                        self.trigger('timeout', {
+                            type: 'timeout',
+                            expiredAfter: timeout
+                        }, request, arguments);
+                        clearTimeout(timeoutId);
+                    }, timeout);
+                }
 
                 //send the request
                 request.send(body);
@@ -687,6 +714,19 @@
                 throw new TypeError('a string is expected, but ' + string + ' [' + (typeof string) + '] given');
             }
             return string;
+        },
+
+        /**
+         * Check whether the given parameter is a positive integer > 0
+         * @param {Number} integer
+         * @returns {Number} value
+         * @throws {TypeError} for non strings
+         */
+        positiveInteger : function(integer){
+            if(parseInt(integer) !== integer || integer <= 0){
+                throw new TypeError('an integer is expected, but ' + integer + ' [' + (typeof integer) + '] given');
+            }
+            return integer;
         },
 
         /**

--- a/src/aja.js
+++ b/src/aja.js
@@ -509,6 +509,9 @@
                 request.onload = function onRequestLoad(){
                     var response = request.responseText;
 
+                    if (timeoutId) {
+                        clearTimeout(timeoutId);
+                    }
                     if(this.status >= 200 && this.status < 300){
                         if(typeof processRes === 'function'){
                             response = processRes(response);
@@ -522,18 +525,21 @@
                 };
 
                 request.onerror = function onRequestError (err){
-                    self.trigger('error', err, arguments);
+                    if (timeoutId) {
+                        clearTimeout(timeoutId);
+                    } else {
+                        self.trigger('error', err, arguments);
+                    }
                 };
 
                 //sets the timeout
                 if (timeout) {
                     timeoutId = setTimeout(function() {
-                        request.abort();
                         self.trigger('timeout', {
                             type: 'timeout',
                             expiredAfter: timeout
                         }, request, arguments);
-                        clearTimeout(timeoutId);
+                        request.abort();
                     }, timeout);
                 }
 

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -128,6 +128,42 @@ describe('aja()', function(){
             .go();
     });
 
+    it('should trigger timeout event after timeout threshold is reached', function(done){
+        aja()
+            .url('/beinglate')
+            .timeout(1)
+            .on('timeout', function(err){
+                expect(err).to.deep.equal({
+                    type: 'timeout',
+                    expiredAfter: 1
+                });
+                done();
+            })
+            .on('success', function(err) {
+                throw new Error('Thou shalt not execute this callback');
+            })
+            .on('error', function(err) {
+                throw new Error('Thou shalt not execute this callback');
+            })
+            .go();
+    });
+
+    it('should not trigger timeout event if the call succeeds', function(done){
+        aja()
+            .url('/beinglate')
+            .timeout(10000)
+            .on('timeout', function(err){
+                throw new Error('Thou shalt not pass from this callback');
+            })
+            .on('success', function(err) {
+                throw new Error('Thou shalt not pass from this callback');
+            })
+            .on('error', function(err) {
+                done();
+            })
+            .go();
+    });
+
     it('should bust cache', function(done){
         aja()
             .url('/time')

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -195,7 +195,7 @@ describe('aja()', function(){
             .type('json')
             .data({ kill: 'bill'})
             .on('204', function(data){
-                expect(data).to.be.empty();
+                expect(data).to.be.empty;
                 done();
             })
             .on('error', function() {

--- a/test/properties/test.js
+++ b/test/properties/test.js
@@ -387,5 +387,36 @@ describe('aja()', function(){
                 expect(a.jsonPadding('cb')).to.equals(a);
             });
         });
+
+
+        describe('timeout()', function(){
+
+            it('should be a function', function(){
+                expect(aja().timeout).to.be.a('function');
+            });
+
+            it('should accept only an integer', function(){
+                expect(function(){ aja().timeout(false); }).to.throw(TypeError);
+                expect(function(){ aja().timeout([]); }).to.throw(TypeError);
+                expect(function(){ aja().timeout(['invalid']); }).to.throw(TypeError);
+                expect(function(){ aja().timeout([1000, 'invalid']); }).to.throw(TypeError);
+                expect(function(){ aja().timeout('anystring'); }).to.throw(TypeError);
+                expect(function(){ aja().timeout({}); }).to.throw(TypeError);
+                expect(function(){ aja().timeout(0); }).to.throw(TypeError);
+                expect(function(){ aja().timeout(-42); }).to.throw(TypeError);
+
+                expect(function(){ aja().timeout(1000); }).to.not.throw();
+            });
+
+            it('should get / set value', function(){
+                expect(aja().timeout(1000).timeout()).to.equal(1000);
+            });
+
+            it('should chain', function(){
+                var a = aja();
+                expect(a.timeout(1000)).to.be.an('object');
+                expect(a.timeout(1000)).to.equals(a);
+            });
+        });
     });
 });

--- a/test/server/middlewares.js
+++ b/test/server/middlewares.js
@@ -27,6 +27,17 @@ var timeMiddleware = function(req, res, next) {
     return next();
 };
 
+//to test timeout
+var timeoutMiddleware = function(req, res, next) {
+    if (/beinglate/.test(req.url)) {
+        res.writeHead(404);
+        setTimeout(function(){
+            return res.end();
+        }, 1000);
+    }
+    return next();
+};
+
 //to mirror the request content
 var mirrorMiddleware = function(req, res, next) {
     var parsed;
@@ -53,6 +64,7 @@ var emptyMiddleware = function(req, res, next) {
 module.exports = [
     jsonpMiddleware,
     timeMiddleware,
+    timeoutMiddleware,
     mirrorMiddleware,
     emptyMiddleware
 ];

--- a/test/server/middlewares.js
+++ b/test/server/middlewares.js
@@ -30,12 +30,13 @@ var timeMiddleware = function(req, res, next) {
 //to test timeout
 var timeoutMiddleware = function(req, res, next) {
     if (/beinglate/.test(req.url)) {
-        res.writeHead(404);
-        setTimeout(function(){
+        setTimeout(function() {
+            res.writeHead(204);
             return res.end();
-        }, 1000);
+        }, 500);
+    } else {
+        return next();
     }
-    return next();
 };
 
 //to mirror the request content


### PR DESCRIPTION
Hey there!
I'm using aja.js as a jQuery's $.ajax replacement on a Backbone-based project. One of my use cases is having an XHR requests auto-retry mechanism (that is, basically: abort&retry the very same call, and then, if there's no response again, let it fail). To do so, I had to tweak aja.js in order *not* to build another layer on top of it, or even worse, switch to a different library.
I've used the good ol' setTimeout for practical reasons, as I've found pretty damn hard to unit test the feature using the XHR's native timeout/ontimeout.
If you spot anything weird we can discuss about it, I'm open to suggestions of course :)
Cheers!